### PR TITLE
Fix oneplus1 (bacon) config in devices.toml

### DIFF
--- a/devices.toml
+++ b/devices.toml
@@ -37,7 +37,7 @@ twrp_url = "https://dl.twrp.me/bullhead/twrp-3.1.1-0-bullhead.img"
 [[device]]
 
 common_name = "OnePlus 1"
-product_name = "OnePlus 1"
+product_name = "MSM8974"
 
 nhos_file = "lineage-14.1-20171009-UNOFFICIAL-bacon.zip"
 nhos_url = "https://build.nethunter.com/installer/oneplus1/lineage-14.1-20171009-UNOFFICIAL-bacon.zip"
@@ -48,8 +48,8 @@ nhfs_url = "https://build.nethunter.com/installer/generic/update-nethunter-gener
 gapps_file = "open_gapps-arm-7.1-mini-20171007.zip"
 gapps_url = "https://build.nethunter.com/installer/gapps/open_gapps-arm-7.1-mini-20171007.zip"
 
-twrp_file = "twrp-3.1.1-0-bullhead.img"
-twrp_url = "https://dl.twrp.me/bullhead/twrp-3.1.1-0-bullhead.img"
+twrp_file = "twrp-3.2.1-0-bacon.img"
+twrp_url = "https://dl.twrp.me/bacon/twrp-3.2.1-0-bacon.img"
 
 [[device]]
 


### PR DESCRIPTION
Fix oneplus1 device product name.
Fix twrp_url path for onplus1. Use bacon instead of bullhead.
Upgrade twrp to 3.2.1 from 3.1.1.

Signed-off-by: Syrt1s M4j0r <d31m05z@gmail.com>